### PR TITLE
Jatin/fixes to chart to deploy to admin

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.14.3
-digest: sha256:94dcb21433168a504b367c78bf4cab6af22508de7ecca63eb30ba4c7fb82b270
-generated: "2022-06-08T15:43:37.599004-07:00"
+  version: 12.1.5
+- name: retool-temporal-services-helm
+  repository: ""
+  version: 0.1.0
+digest: sha256:217d7ef5882da25f12269a0344121736cccdfb5a14ee9e3795b8d55688ad2cfe
+generated: "2022-12-22T13:53:33.606385-08:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
     email: engineering+helm@retool.com
 dependencies:
   - name: postgresql
-    version: 10.14.3
+    version: 12.1.5
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: retool-temporal-services-helm

--- a/charts/retool-temporal-services-helm/templates/server-deployment.yaml
+++ b/charts/retool-temporal-services-helm/templates/server-deployment.yaml
@@ -117,21 +117,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "temporal.persistence.secretName" (list $ "visibility") }}
                   key: {{ include "temporal.persistence.secretKey" (list $ "visibility") }}
-            - name: DEFAULT_NAMESPACE
-              value: workflows
-            - name: DB
-              value: postgresql
-            - name: POSTGRES_SEEDS
-              value: "{{ $.Values.server.config.persistence.default.sql.host }}"
-            - name: POSTGRES_USER
-              value: "{{ $.Values.server.config.persistence.default.sql.user }}"
-            - name: DB_PORT
-              value: "{{ $.Values.server.config.persistence.default.sql.port }}"
-            - name: POSTGRES_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "temporal.persistence.secretName" (list $ "default") }}
-                  key: {{ include "temporal.persistence.secretKey" (list $ "default") }}
           {{- if $.Values.server.versionCheckDisabled }}
             - name: TEMPORAL_VERSION_CHECK_DISABLED
               value: "1"
@@ -156,7 +141,7 @@ spec:
             - name: dynamic-config
               mountPath: /etc/temporal/dynamic_config
             {{- if $.Values.server.additionalVolumeMounts }}
-            {{- toYaml $.Values.server.additionalVolumeMounts | nindent 12}}  
+            {{- toYaml $.Values.server.additionalVolumeMounts | nindent 12}}
             {{- end }}
           resources:
             {{- toYaml (default $.Values.server.resources $serviceValues.resources) | nindent 12 }}
@@ -179,7 +164,7 @@ spec:
             - key: dynamic_config.yaml
               path: dynamic_config.yaml
         {{- if $.Values.server.additionalVolumes }}
-        {{- toYaml $.Values.server.additionalVolumes | nindent 8}}  
+        {{- toYaml $.Values.server.additionalVolumes | nindent 8}}
         {{- end }}
       {{- with (default $.Values.server.nodeSelector $serviceValues.nodeSelector) }}
       nodeSelector:

--- a/charts/retool-temporal-services-helm/values.yaml
+++ b/charts/retool-temporal-services-helm/values.yaml
@@ -391,6 +391,9 @@ grafana:
          url: https://raw.githubusercontent.com/temporalio/dashboards/helm/misc/worker-service-specific.json
          datasource: TemporalMetrics
 
+postgresql:
+  enabled: false
+
 cassandra:
   enabled: false
 

--- a/templates/deployment_workflows.yaml
+++ b/templates/deployment_workflows.yaml
@@ -15,7 +15,6 @@ spec:
   selector:
     matchLabels:
       retoolService: {{ template "retool.fullname" . }}-workflow-backend
-{{- include "retool.selectorLabels" . | nindent 6 }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
@@ -28,7 +27,6 @@ spec:
 {{- end }}
       labels:
         retoolService: {{ template "retool.fullname" . }}-workflow-backend
-{{- include "retool.selectorLabels" . | nindent 8 }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}

--- a/templates/deployment_workflows_worker.yaml
+++ b/templates/deployment_workflows_worker.yaml
@@ -15,7 +15,6 @@ spec:
   selector:
     matchLabels:
       retoolService: {{ template "retool.fullname" . }}-workflow-worker
-{{- include "retool.selectorLabels" . | nindent 6 }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
@@ -34,7 +33,6 @@ spec:
 {{- end }}
       labels:
         retoolService: {{ template "retool.fullname" . }}-workflow-worker
-{{- include "retool.selectorLabels" . | nindent 8 }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}


### PR DESCRIPTION
seems like we were conflating some selectors so we'd be getting main backend requests to the worker/workflows-backend x.x

also deleting some postgres configuration that makes the temporal stuff try to connect to postgres