### PR TITLE
Add support for more secrets as env variables

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -191,6 +191,10 @@ spec:
         envFrom:
         - secretRef:
             name: {{ .Values.externalSecrets.name }}
+        {{- range .Values.externalSecrets.secrets }}
+        - secretRef:
+            name: {{ .name }}
+        {{- end }}
         {{- end }}
         {{- if .Values.externalSecrets.externalSecretsOperator.enabled  }}
         envFrom:

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -153,6 +153,10 @@ spec:
         envFrom:
         - secretRef:
             name: {{ .Values.externalSecrets.name }}
+        {{- range .Values.externalSecrets.secrets }}
+        - secretRef:
+            name: {{ .name }}
+        {{- end }}
         {{- end }}
         {{- if .Values.externalSecrets.externalSecretsOperator.enabled  }}
         envFrom:

--- a/templates/deployment_workflows.yaml
+++ b/templates/deployment_workflows.yaml
@@ -194,6 +194,10 @@ spec:
         envFrom:
         - secretRef:
             name: {{ .Values.externalSecrets.name }}
+        {{- range .Values.externalSecrets.secrets }}
+        - secretRef:
+            name: {{ .name }}
+        {{- end }}
         {{- end }}
         {{- if .Values.externalSecrets.externalSecretsOperator.enabled  }}
         envFrom:

--- a/templates/deployment_workflows_worker.yaml
+++ b/templates/deployment_workflows_worker.yaml
@@ -215,6 +215,10 @@ spec:
         envFrom:
         - secretRef:
             name: {{ .Values.externalSecrets.name }}
+        {{- range .Values.externalSecrets.secrets }}
+        - secretRef:
+            name: {{ .name }}
+        {{- end }}
         {{- end }}
         {{- if .Values.externalSecrets.externalSecretsOperator.enabled  }}
         envFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -194,6 +194,10 @@ externalSecrets:
   # This mode only allows a single secret name to be provided.
   enabled: false
   name: retool-config
+  # Array of secrets to be use as env variables. (Optional)
+  secrets: []
+    # - name: retool-config
+    # - name: retool-db
   # Support for External Secrets Operator: https://github.com/external-secrets/external-secrets
   externalSecretsOperator:
     enabled: false


### PR DESCRIPTION
Hi,

I need to have more than 1 secret as environment variables, and don't need to use the External Secrets Operator for that.
Would it be possible to make a small change in the charts to support an array of secrets, like proposed in this PR?

Thank you.