### PR TITLE
only set environment variables if using self-managed temporal

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -84,13 +84,15 @@ spec:
           - name: DBCONNECTOR_QUERY_TIMEOUT_MS
             value: {{ .Values.config.dbConnectorTimeout | quote }}
           {{- end }}
-          {{- if .Values.workflows.enabled }}
+          {{- if and (.Values.workflows.enabled) (or (.Values.retool-temporal-services-helm.enabled) (.Values.workflows.temporal.enabled)) }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST
             value: {{ template "retool.temporal.host" . }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT
             value: {{ template "retool.temporal.port" . }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_NAMESPACE
             value: {{ template "retool.temporal.namespace" . }}
+          {{- end }}
+          {{- if (.Values.workflows.enabled) }}
           - name: WORKFLOW_BACKEND_HOST
             value: http://{{ template "retool.fullname" . }}-workflow-backend
           {{- end }}

--- a/templates/deployment_workflows.yaml
+++ b/templates/deployment_workflows.yaml
@@ -73,12 +73,14 @@ spec:
           {{- end }}
           - name: DISABLE_DATABASE_MIGRATIONS
             value: "true"
+          {{- if or (.Values.retool-temporal-services-helm.enabled) (.Values.workflows.temporal.enabled) }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST
             value: {{ template "retool.temporal.host" . }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT
             value: {{ template "retool.temporal.port" . }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_NAMESPACE
             value: {{ template "retool.temporal.namespace" . }}
+          {{- end }}
           {{- if (.Values.workflows.temporal).sslEnabled }}
           - name: WORKFLOW_TEMPORAL_TLS_ENABLED
             value: "true"

--- a/templates/deployment_workflows_worker.yaml
+++ b/templates/deployment_workflows_worker.yaml
@@ -81,12 +81,14 @@ spec:
           {{- end }}
           - name: DISABLE_DATABASE_MIGRATIONS
             value: "true"
+          {{- if or (.Values.retool-temporal-services-helm.enabled) (.Values.workflows.temporal.enabled) }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST
             value: {{ template "retool.temporal.host" . }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT
             value: {{ template "retool.temporal.port" . }}
           - name: WORKFLOW_TEMPORAL_CLUSTER_NAMESPACE
             value: {{ template "retool.temporal.namespace" . }}
+          {{- end }}
           {{- if (.Values.workflows.temporal).sslEnabled }}
           - name: WORKFLOW_TEMPORAL_TLS_ENABLED
             value: "true"

--- a/values.yaml
+++ b/values.yaml
@@ -399,9 +399,9 @@ workflows:
   # This allows configuring a Retool Workflows deployment that uses your own Temporal cluster
   # instead of deploying a new one. Set enabled to true and add the config variables.
   # NOTE: Temporal Frontend with required TLS or mTLS not currently supported
-  temporal: {}
+  temporal:
     # set enabled to true if using a pre-existing temporal cluster
-    # enabled: false
+    enabled: false
     # discoverable service name for the temporal frontend service
     # host:
     # discoverable service port for the temporal frontend service


### PR DESCRIPTION
See inline comments, this change supports Hybrid On Prem configuration - that allows you to not configure workers/backends with env vars