### PR TITLE
[fix] Use correct secret name for PostgreSQL password

### DIFF
--- a/templates/deployment_backend.yaml
+++ b/templates/deployment_backend.yaml
@@ -154,7 +154,13 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
-                key: postgresql-password
+                # `postgres` is the default admin username for postgres in the subchart we use, so it needs the admin password
+                # if a different username is picked, then it needs the custom password instead.
+                {{- if eq .Values.postgresql.auth.username "postgres" }}
+                key: postgres-password
+                {{- else }}
+                key: password
+                {{- end }}
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}

--- a/templates/deployment_jobs.yaml
+++ b/templates/deployment_jobs.yaml
@@ -114,7 +114,7 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
-                key: postgresql-password
+                key: postgres-password
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}

--- a/templates/deployment_workflows.yaml
+++ b/templates/deployment_workflows.yaml
@@ -157,7 +157,7 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
-                key: postgresql-password
+                key: postgres-password
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}

--- a/templates/deployment_workflows_worker.yaml
+++ b/templates/deployment_workflows_worker.yaml
@@ -178,7 +178,7 @@ spec:
               secretKeyRef:
           {{- if  .Values.postgresql.enabled }}
                 name: {{ template "retool.postgresql.fullname" . }}
-                key: postgresql-password
+                key: postgres-password
           {{- else }}
                 {{- if .Values.config.postgresql.passwordSecretName }}
                 name: {{ .Values.config.postgresql.passwordSecretName }}


### PR DESCRIPTION
## What
When the chart customer enables postgres subchart, we attempt to read db password from `postgresql-password` key from a secret that is created by postgres subchart. However, PostgreSQL Helm chart [uses](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/templates/secrets.yaml#L42C9-L42C9) `postgres-password` as a key. 

This change updates our chart to use correct secret key. 
The problem was fixed in the main Retool Helm chart in these PRs: https://github.com/tryretool/retool-helm/pull/97 and https://github.com/tryretool/retool-helm/pull/114 .