### PR TITLE
Added extraPaths to ingress template

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: retool-wf
 description: A Helm chart for Kubernetes
 type: application
-version: 4.12.2
+version: 4.13.0
 maintainers:
   - name: Retool Engineering
     email: engineering+helm@retool.com

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Modify `values.yaml`:
 - If you are implementing TLS for your Retool instance, uncomment `ingress.tls` and:
     - Specify the name of the SSL certificate to use as the value of `ingress.tls.secretName`.
     - Specify an array containing the hostname where you will access Retool (the same value you configured for `ingress.hosts.host`).
+- If you are want more control over the the ingress path, for example in order to create a rediect from port 80 to 443 with aws-load-balancer-controller, you may use `ingress.extraPaths`
+    - Specify the full object of a valid ingress path like shown in [k8s docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource) or in [values.yaml: ingress.extraPaths](values.yaml#L250)
 
 GKE-specific configurations:
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Modify `values.yaml`:
 - If you are implementing TLS for your Retool instance, uncomment `ingress.tls` and:
     - Specify the name of the SSL certificate to use as the value of `ingress.tls.secretName`.
     - Specify an array containing the hostname where you will access Retool (the same value you configured for `ingress.hosts.host`).
-- If you are want more control over the the ingress path, for example in order to create a rediect from port 80 to 443 with aws-load-balancer-controller, you may use `ingress.extraPaths`
-    - Specify the full object of a valid ingress path like shown in [k8s docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource) or in [values.yaml: ingress.extraPaths](values.yaml#L250)
+- If you are want more control over the the ingress path, for example in order to create a rediect from port 80 to 443 with aws-load-balancer-controller, you may use `ingress.hosts.extraPaths`
+    - Specify the full object of a valid ingress path like shown in [k8s docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource) or in [values.yaml: ingress.hosts.extraPaths](values.yaml#L250)
 
 GKE-specific configurations:
 

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -49,6 +49,9 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+          {{- with .extraPaths }}
+{{ toYaml . | indent 10 }}
+          {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
             {{- if and $pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}

--- a/values.yaml
+++ b/values.yaml
@@ -244,6 +244,17 @@ ingress:
   # - host: retool.example.com
   #   paths:
   #     - path: /
+  # For supporting other ingress controllers that require customizing the .backend.service.name and .backend.service.port.name, 
+  # like AWS ALB extraPaths allows that customization, and it takes precedence in the list of paths of for the host, 
+  # this is in order to allow a rule like ssl-redirect from port 80-->443 to be first ( otherwise there wouldn't be a redirect )
+  #   extraPaths:
+  #     - path: /*
+  #       backend:
+  #         service:
+  #           name: ssl-redirect
+  #           port:
+  #             name: use-annotation
+  #       pathType: ImplementationSpecific
   tls:
   # - secretName: retool.example.com
   #   hosts:


### PR DESCRIPTION
Hello, 

in order to allow Redirecting plain HTTP traffic to HTTPS (Via HTTP_301), 
while using an AWS ALB ingress via the [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.6/guide/tasks/ssl_redirect/),
it is required to modify the `name` of the backend and the `port.name`.

To that end, I've created this PR which allows engineers to use `Values.ingress.hosts[].extraPaths`
the paths would then be added to the top\* of the paths list of an host.

\* For ALB it is required that the redirect rule would be first, otherwise the rule that allows HTTP comes by-default first, and if there is a redirect at lower in the list of `paths[]`, Funnily enough the redirect comes right after, meaning the redirect rule would never be reached.